### PR TITLE
add n/a for structs to write_tsv

### DIFF
--- a/ft_write_tsv.m
+++ b/ft_write_tsv.m
@@ -63,6 +63,8 @@ else
   % write boolean as 'True' or 'False'
   if isempty(val)
     val = 'n/a';
+  elseif isstruct(val)
+    val = 'n/a';
   elseif isnan(val)
     val = 'n/a';
   elseif islogical(val)


### PR DESCRIPTION
this is a strange edgecase, I know... - but I have an xdf file that apparently has for the field "unit" an empty struct, which crashes here.